### PR TITLE
Correct arguments of shinyApp() function

### DIFF
--- a/03-structure.Rmd
+++ b/03-structure.Rmd
@@ -571,7 +571,7 @@ app_server <- function(input, output, session) {
   callModule(mod_b_server, "mod_ui_2", react = res)
 }
 
-shinyApp(ui, server)
+shinyApp(app_ui, app_server)
 ```
 
 This strategy works well, but for large Shiny Apps it might be hard to handle large lists of reactive outputs / inputs and to keep track of how things are organized. 


### PR DESCRIPTION
Executing the shinyApp() function returns an error because the arguments are not correct. This PR fixes the arguments.