### PR TITLE
Consistency on RStudio, GitHub and GitLab names.

### DIFF
--- a/02-planning-ahead.Rmd
+++ b/02-planning-ahead.Rmd
@@ -115,7 +115,7 @@ The project manager will be the one that kicks off the project, and write the fi
 If you follow this book's workflow, this person will first create a `{golem}` project, fill the information, and define the application structure by providing the main modules, and potentially work on the prototyped UI of the app. 
 
 Once the skeleton of the app is created, this person in charge will list all the things that have to be done.
-We strongly suggest to use git with a graphical interface (Gitlab, Github, Bitbucket, ...), as the graphical interface of these services will help you manage the project. 
+We strongly suggest to use git with a graphical interface (GitLab, GitHub, Bitbucket, ...), as the graphical interface of these services will help you manage the project. 
 These tasks are defined as issues, and will be closed during development.
 These interfaces can also be used to set continuous integration.
 

--- a/03-structure.Rmd
+++ b/03-structure.Rmd
@@ -143,7 +143,7 @@ run_app()
 
 #### RStudio Connect, Shiny Server, shinyapps.io
 
-Sending a Shiny application to a Rstudio product currently requires placing an R script at the root of your package directory.
+Sending a Shiny application to a RStudio product currently requires placing an R script at the root of your package directory.
 
 To run  your application on these platforms, you will need to use a "standard" Shiny filename pattern, _i.e._ an `app.R` file or `ui.R` / `server.R`, and send the whole thing to the server. 
 To integrate your "Shiny App as a package" into Connect or Shiny Server, you can adopt two strategies: 

--- a/04-golem.Rmd
+++ b/04-golem.Rmd
@@ -85,7 +85,7 @@ Let's focus on the architecture of the default `{golem}` app, and present what p
 library(magrittr)
 ```
 
-You can create a `{golem}` project, here called `golex`, with Rstudio "New project" creation or with command line:
+You can create a `{golem}` project, here called `golex`, with RStudio "New project" creation or with command line:
 
 ```{r 04-golem-7, eval=FALSE}
 golem::create_golem("golex")

--- a/11-step-by-step-build.Rmd
+++ b/11-step-by-step-build.Rmd
@@ -238,7 +238,7 @@ You can set up various continuous integration services automatically by using fu
 + AppVeyor with `usethis::use_appveyor()`
 + GitLab CI with `use_gitlab_ci()`
 + Circle CI with `use_circleci()`
-+ Github Actions with `use_github_actions()`
++ GitHub Actions with `use_github_actions()`
 + Jenkins with `use_jenkins()`
 
 If ever you want to add badges to your `README` files for these services, `{usethis}` also comes with a series of functions to do just that: `use_travis_badge()`, `use_appveyor_badge()`, `use_circleci_badge()` and `use_github_actions_badge()`.

--- a/12-step-by-step-secure.Rmd
+++ b/12-step-by-step-secure.Rmd
@@ -623,7 +623,7 @@ In this example, there is just one call to a script, one located at `renv/activa
 
 As we have initiated an empty project, we do not have any dependencies here. 
 If you run this command in a project that already has scripts and dependencies, `{renv}` will try to locate them all, and add them to this file. 
-Note that these packages can come from CRAN, Bioconductor, GitHub, Gitlab, 
+Note that these packages can come from CRAN, Bioconductor, GitHub, GitLab, 
 Bitbucket, and even local repositories. 
 
 The `renv/` folder contains a series of files that that store your settings and the necessary packages, using a structure that mimics a local repository.
@@ -821,7 +821,7 @@ At the time of writing these lines, there is no native support of `{renv}` (with
 Developers have their own R versions and operating systems.
 If you want to be able to correctly deploy your application, you will use a Docker container.
 Then, why not already developing inside a Docker container having the exact same architecture than the one you will deploy ?
-This is possible to use ["rocker" containers](https://hub.docker.com/r/rocker/r-ver) to build your application inside the container, using the embedded Rstudio Server or directly an exported R console.  
+This is possible to use ["rocker" containers](https://hub.docker.com/r/rocker/r-ver) to build your application inside the container, using the embedded RStudio Server or directly an exported R console.  
 You can even combine developing in a Docker container with the use of `{renv}`.
 
 #### Read more about Docker 

--- a/13-secure.Rmd
+++ b/13-secure.Rmd
@@ -4,7 +4,7 @@
 
 "Friends do not let friends work on a coding project without version control." 
 You might have heard this before, without really considering what this means. 
-Or maybe you are convinced about this saying, but have not had the opportunity to use git, GitHub or Gitlab for versioning your applications. 
+Or maybe you are convinced about this saying, but have not had the opportunity to use git, GitHub or GitLab for versioning your applications. 
 If so, now is the time for a workflow change!
 
 ### Why Version Control?
@@ -104,7 +104,7 @@ Even when working alone.
 
 ### Issues
 
-If you are working with a remote tool with a graphical interface like Gitlab, GitHub or Bitbucket, there is a good chance you will be using issues. 
+If you are working with a remote tool with a graphical interface like GitLab, GitHub or Bitbucket, there is a good chance you will be using issues. 
 Issues are "notes" or "tickets" that can be used to track a bug or to suggest a feature. 
 This tool is crucial when it comes to project management: they are the perfect spot for organizing and discussing ideas, but also to have an overview of what has been done, what is currently done and what is left to be done. 
 Issue can also be used as a discussion medium with beta testers, clients or sponsors. 
@@ -116,7 +116,7 @@ In other words, when you send code to the centralized server, you can link this 
 
 ### With RStudio
 
-Git is very well integrated to the Rstudio IDE, and using `git` can be as simple as clicking on a button from time to time. 
+Git is very well integrated to the RStudio IDE, and using `git` can be as simple as clicking on a button from time to time. 
 If you are using RStudio, you will find a pull/push button, a stage & commit interface, a tool for visualizing differences in files. 
 Everything you need to get started is there. 
 

--- a/14-deploy-with-golem.Rmd
+++ b/14-deploy-with-golem.Rmd
@@ -69,18 +69,18 @@ When using `{golem}`, you can open the `dev/03_deploy.R` and find the functions 
 
 At the time of writing this book, there are two main ways to deploy a shiny app on a server: 
 
-+ Rstudio's solutions
++ RStudio's solutions
 + A docker based solution
 
 ### RStudio Environments
 
-Rstudio proposes three services to deploy Shiny application : 
+RStudio proposes three services to deploy Shiny application : 
 
 + shinyapps.io, an on-premise solution that can serve Shiny application (freemium)
 
 + Shiny-server, a software you have to install on your own server, and that can be used to deploy multiple applications (you can find either an open source or a professional edition)
 
-+ Rstudio connect, a server-based solution that can deploy Shiny applications and markdown documents (and other kind of content)
++ RStudio connect, a server-based solution that can deploy Shiny applications and markdown documents (and other kind of content)
 
 Each of these platforms has its own function to create an `app.R` file that is to be used as a launch script of each platform.
 


### PR DESCRIPTION
So far, I've found that in some places it is used alternative capitalizations for RStudio, GitHub and GitLab:
```bash
jcrodriguez@zenbook:engineering-shiny-book$ grep "Rstudio" *.Rmd | wc -l
7
jcrodriguez@zenbook:engineering-shiny-book$ grep "RStudio" *.Rmd | wc -l
19

jcrodriguez@zenbook:engineering-shiny-book$ grep "GitHub" *.Rmd | wc -l
24
jcrodriguez@zenbook:engineering-shiny-book$ grep "Github" *.Rmd | wc -l
2

jcrodriguez@zenbook:engineering-shiny-book$ grep "GitLab" *.Rmd | wc -l
6
jcrodriguez@zenbook:engineering-shiny-book$ grep "Gitlab" *.Rmd | wc -l
4
```

According to the 'most-used-alternative', and also because they are the correct names, capitalizations were corrected in some places.

By the way, I'm still in the sixth chapter, how freaking interesting is this book! Congrats!