### PR TITLE
Fix `packageMetrics2` installation block options

### DIFF
--- a/01-big-shiny.Rmd
+++ b/01-big-shiny.Rmd
@@ -436,7 +436,7 @@ if (!requireNamespace("packageMetrics2")) {
 
 At the time of writing these lines, the package is not on CRAN and can be installed using the following line of code:
 
-```{r 01-big-shiny-24, echo = FALSE, include = FALSE}
+```{r 01-big-shiny-24, eval = FALSE}
 # Installing {packageMetrics2} from GitHub
 remotes::install_github("MangoTheCat/packageMetrics2")
 ```


### PR DESCRIPTION
Currently the instructions on how to install packageMetrics2 is hidden. I've just copied the options for other package installation blocks.

![image](https://user-images.githubusercontent.com/8420419/137867212-754d2587-2e46-42f9-8e46-2370249f4ff7.png)
