### PR TITLE
Minor Typo - "codebase" vs. "code-base"

### DIFF
--- a/01-big-shiny.Rmd
+++ b/01-big-shiny.Rmd
@@ -303,7 +303,7 @@ hexmake_cloc
 ```
 
 
-One thing that this package also allows is counting the number of lines of commented code: it's usually a good sign to see that a package has comments in its code-base, as it will allow to work more safely in the future, provided that this metric doesn't reveal that large portions of the application are "commented code" (as opposed to "code comments").
+One thing that this package also allows is counting the number of lines of commented code: it's usually a good sign to see that a package has comments in its codebase, as it will allow to work more safely in the future, provided that this metric doesn't reveal that large portions of the application are "commented code" (as opposed to "code comments").
 For example, here we can see that `{hemake}` has `r dplyr::filter(hexmake_cloc, language == "R") %>% dplyr::pull(loc)` lines of R code, which come with `r dplyr::filter(hexmake_cloc, language == "R") %>% dplyr::pull(comment_lines)` lines of code comments.
 
 #### B. Cyclomatic complexity {.unnumbered}


### PR DESCRIPTION
In a few places throughout the book, the word "codebase" is spelled as "code-base" (see below, but also chapter 1, 3, 12, 14).