### PR TITLE
Fix typo

### DIFF
--- a/00-app-presentation.Rmd
+++ b/00-app-presentation.Rmd
@@ -70,7 +70,7 @@ The code is available at [github.com/ColinFay/tidytuesday201942](https://github.
 ## `{minifying}` {.unnumbered}
 
 `{minifying}` is an application to minify CSS, JavaScript, HTML, and JSON files.
-It was built built by Colin as a use case for the workflow of this book.
+It was built by Colin as a use case for the workflow of this book.
 You will find the details of how this app was constructed in the Appendix, "*Use case: Building an App, from Start to Finish*".
 
 Figure \@ref(fig:00-app-presentation-3) is a screenshot of this application.


### PR DESCRIPTION
The word "built" was used twice in a row. The proposed change corrects this.