### PR TITLE
Add a missing whitespace 

### DIFF
--- a/01-big-shiny.Rmd
+++ b/01-big-shiny.Rmd
@@ -8,7 +8,7 @@
 
 If you are reading this page, chances are you already know what a `{shiny}` application (sometimes shortened as "`{shiny}` app") is—**a web application that communicates with R, built in R, and working with R**.
 The beauty of `{shiny}` [@R-shiny] is that it makes it easy for someone already familiar with R to create a small app in a matter of hours.
-With small and minimal `{shiny}` apps, no knowledge of HTML (HyperText Markup Language), CSS(Cascading Style Sheets) or JavaScript is required, and you do not have to think about technical elements that usually come with web applications—for example, you do not have to think about the port the application is served on: `{shiny}` picks one for you.[^big-shiny-1]
+With small and minimal `{shiny}` apps, no knowledge of HTML (HyperText Markup Language), CSS (Cascading Style Sheets) or JavaScript is required, and you do not have to think about technical elements that usually come with web applications—for example, you do not have to think about the port the application is served on: `{shiny}` picks one for you.[^big-shiny-1]
 Same goes for serving external dependencies: the application comes with its set of CSS and JavaScript dependencies that a common `{shiny}` developer does not need to worry about.
 And that is probably one of the main reasons why this package has become so successful over the years—**with very little training, you can rapidly create a proof-of-concept (PoC) for a data product, showcase an algorithm, or present your results in an elegant and accessible user interfaces**.
 


### PR DESCRIPTION
This PR adds a missing space between "CSS" and "(Cascading Style Sheets)" in the sentence. 

I assign the copyright of this contribution to Colin Fay, Vincent Guyader, Cervan Girard and Sébastien Rochette.